### PR TITLE
use CanCan::Ability#add_rule to add invitational rules

### DIFF
--- a/lib/invitational/cancan.rb
+++ b/lib/invitational/cancan.rb
@@ -1,6 +1,7 @@
 module Invitational
   module CanCan
     module Ability
+      include ::CanCan::Ability
 
       def can(action = nil, subject = nil, conditions = nil, &block)
         if conditions && conditions.has_key?(:roles)
@@ -10,7 +11,7 @@ module Invitational
           block ||= setup_role_based_block_for roles, subject, action, false
         end
 
-        rules << ::CanCan::Rule.new(true, action, subject, conditions, block)
+        add_rule ::CanCan::Rule.new(true, action, subject, conditions, block)
       end
 
       def cannot(action = nil, subject = nil, conditions = nil, &block)
@@ -21,7 +22,7 @@ module Invitational
           block ||= setup_role_based_block_for roles, subject, action, true
         end
 
-        rules << ::CanCan::Rule.new(false, action, subject, conditions, block)
+        add_rule ::CanCan::Rule.new(false, action, subject, conditions, block)
       end
 
       def setup_role_based_block_for roles, subject, action, role_specific


### PR DESCRIPTION
With updated versions of CanCan, I received the following error.

```
NoMethodError:
        undefined method `values_at' for nil:NilClass
```

This is because CanCan now puts rules in a `rules_index` as well as the normal `rules` object.

I was able to resolve this by using CanCan's built-in `add_rule` method. To gain access to that method, I added `include CanCan::Ability` to `lib/invitational/cancan.rb`. In ability.rb, you now only have to include `Invitational::CanCan::Ability`.