### PR TITLE
Generated claim hash should be unpredictable

### DIFF
--- a/app/modules/invitational/invitation_core.rb
+++ b/app/modules/invitational/invitation_core.rb
@@ -80,7 +80,7 @@ module Invitational
 
     def setup_hash
       self.date_sent = DateTime.now
-      self.claim_hash = Digest::SHA1.hexdigest(email + date_sent.to_s)
+      self.claim_hash = SecureRandom.alphanumeric(40)
     end
 
     def standard_role?

--- a/spec/invitational/models/invitation_spec.rb
+++ b/spec/invitational/models/invitation_spec.rb
@@ -27,6 +27,15 @@ describe Invitational::Invitation do
       Then {new_invite.claim_hash.should_not be_nil}
       And  {new_invite.date_sent.should_not be_nil}
     end
+
+    context "Generates Claim hash that is not predictable" do
+      Given(:first_invite) {Invitation.new(email: "test999@d-i.co", invitable: entity1, role: :user)}
+      Given(:second_invite) {Invitation.new(email: "test999@d-i.co", invitable: entity2, role: :user)}
+
+      When {first_invite.save && second_invite.save}
+
+      Then {first_invite.claim_hash != second_invite.claim_hash}
+    end
   end
 
   context "Role Title" do


### PR DESCRIPTION
Currently, when `claim_hash` is generated, target email and current time (with seconds precision) is used to generate SHA1. Unfortunately, this is very predictable, and if the gem happen to be used to confirm email,– an attacker can easily guess the claim hash value.

This change switches from hashing the email to generating a truly random string of an equal length (40 characters).