### PR TITLE
Includes various gemspec/Gemfile updates

### DIFF
--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+invitational

--- a/Gemfile
+++ b/Gemfile
@@ -23,5 +23,4 @@ group :test do
   gem 'activerecord'
   gem 'actionpack' # action_controller, action_view
   gem 'sprockets'
-  gem 'rspec-given'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    invitational (1.4.3)
-      cancancan (~> 1.13)
+    invitational (1.5.0)
+      cancancan (~> 2.0)
       rails (> 4.0)
 
 GEM
@@ -70,7 +70,7 @@ GEM
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     builder (3.2.4)
-    cancancan (1.17.0)
+    cancancan (2.3.0)
     capybara (3.35.3)
       addressable
       mini_mime (>= 0.1.3)
@@ -89,8 +89,8 @@ GEM
     erubi (1.10.0)
     given_core (3.8.2)
       sorcerer (>= 0.3.7)
-    globalid (0.4.2)
-      activesupport (>= 4.2.0)
+    globalid (0.5.2)
+      activesupport (>= 5.0)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
     jquery-rails (4.4.0)
@@ -105,11 +105,13 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.4)
-    nio4r (2.5.5)
+    nio4r (2.5.8)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -182,7 +184,7 @@ GEM
     thor (1.1.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
-    websocket-driver (0.7.3)
+    websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     xpath (3.2.0)

--- a/invitational.gemspec
+++ b/invitational.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["{spec}/**/*"]
 
   s.add_dependency "rails", "> 4.0"
-  s.add_dependency "cancancan", "~> 1.13"
+  s.add_dependency "cancancan", "~> 2.0"
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "combustion"


### PR DESCRIPTION
* Added a .ruby-gemset file for those using rvm as their Ruby version
manager
* Removed rspec-given from Gemfile since running rspec was throwing up a
complaint about it being included twice
* Updated gemspec to incude version 2.x of cancancan, as 1.x was
throwing some deprecation warnings in Rails due to class autoloading
issues
* Includes other various patch-level updates to other dependencies